### PR TITLE
Fix error when using byContentVal decorator

### DIFF
--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -28,6 +28,7 @@ function makeDecorator(callback) {
 let byContentVal = makeDecorator(function() {
     return function (target, key, descriptor) {
         if (target.addProperty) {
+            descriptor.writable = true;
             target.addProperty(key, (element) => {
                 return element && element.innerText;
             });

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -183,6 +183,20 @@ describe("DOMModel", () => {
             option.setAttribute("value", "optionNew");
         });
 
+        it("updates the value when content changes", (done) => {
+            let option = element.querySelector(`option[value="option2"]`);
+            expect(option).to.exist;
+            element.addEventListener("_updateModel", (event) => {
+                let newValue = event.detail[0].value;
+                expect(newValue).to.exist;
+                expect(newValue).to.be.an('array');
+                expect(newValue).to.have.lengthOf(4);
+                expect(newValue[1].text).to.equal("Changed Option Label");
+                done();
+            });
+            option.innerText = 'Changed Option Label';
+        });
+
         it("updates when removing item", (done) => {
             let option = element.querySelector(`option[value="option2"]`);
             expect(option).to.exist;


### PR DESCRIPTION
I was getting an error about writing to a read-only property when I used `@byContentVal`

## Description

I found that the decorators that worked for me marked the property as writable. I fixed `byContentVal` to do the same.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I ran the included unit tests

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.