### PR TITLE
Add a @byContent selector for reparenting child content

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This utility is reponsible from converting a DOM node to a model. The model is d
 * [byBooleanAttrVal](#bybooleanattrval)
 * [byJsonAttrVal](#byjsonattrval)
 * [byContentVal](#bycontentval)
+* [byContent](#bycontent)
 * [byChildContentVal](#bychildcontentval)
 * [byChildRef](#bychildref)
 * [byModel](#bymodel)
@@ -216,6 +217,44 @@ const model = new Model().fromDOM(document.getElementById("elem"));
 model ~ {
     label: "My Label"
 }
+```
+
+#### byContent
+This decorator allows you to capture the contents of a child of the element that is matched.
+by a CSS selector. The can be used to reparent arbitrary child DOM content, which may not
+have been rendered with React, into your web component. Once parsing has occurred, the field
+in the model will contain a React component that represents the DOM content that will be
+reparented.
+
+The DOM content will be moved when the React component is mounted. And, the content
+will be put back in its original location if the React component is later unmounted.
+```js
+@byContent(attrName:selector) - the CSS selector that will match the child node.
+```
+```js
+class Model extends DOMModel {
+    @byContent('.content') content;
+}
+<div id="elem">
+    <div class="content">
+        This will be reparented
+    </div>
+</div>
+<div id="mount-point"/>
+
+const model = new Model().fromDOM(document.getElementById("elem"));
+ReactDOM.render(<div>{ model.content }</div>, document.getElementById("mount-point"))
+
+// Once React has rendered the above component, the DOM will look like this
+
+<div id="elem">
+    <!-- placeholder for DIV -->
+</div>
+<div id="mount-point">
+    <div class="content">
+        This will be reparented
+    </div>
+</div>
 ```
 
 #### byChildContentVal

--- a/README.md
+++ b/README.md
@@ -220,11 +220,11 @@ model ~ {
 ```
 
 #### byContent
-This decorator allows you to capture the contents of a child of the element that is matched.
-by a CSS selector. The can be used to reparent arbitrary child DOM content, which may not
-have been rendered with React, into your web component. Once parsing has occurred, the field
-in the model will contain a React component that represents the DOM content that will be
-reparented.
+This decorator allows you to capture a DOM node that is matched by a CSS selector.
+This can be used to reparent arbitrary child DOM content, which may not have been
+rendered with React, into your web component. Once parsing has occurred, the field
+in the model will contain a React component that represents the DOM content that
+will be reparented.
 
 The DOM content will be moved when the React component is mounted. And, the content
 will be put back in its original location if the React component is later unmounted.

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -10,7 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import DOMNode from './DOMNode';
-import EmbedNode from './EmbedNode'
+import EmbedNode from './EmbedNode';
+import React from 'react';
 
 var _idCount = 0;
 

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -33,30 +33,30 @@ function makeDOMNode(target, selector) {
 }
 
 function findCommentNode(element, selector) {
-	for(let i = 0; i < element.childNodes.length; i++) {
-		let node = element.childNodes[i];
-		if( node.nodeType === 8
-			&& node._reactComponentDataNode
-			&& node._reactComponentDataNode.selector === selector) {
-			return node;
-		}
-	}
+    for(let i = 0; i < element.childNodes.length; i++) {
+        let node = element.childNodes[i];
+        if( node.nodeType === 8
+            && node._reactComponentDataNode
+            && node._reactComponentDataNode.selector === selector) {
+            return node;
+        }
+    }
 }
 
 function queryChildren(element, selector, all = false) {
-	if (typeof selector !== 'string') {
-		console.warn('Query selector must be string!');
-		return;
-	}
-	let id = element.id,
-		guid = element.id = id || 'query_children_' + _idCount++,
-		attr = '#' + guid + ' > ',
-		scopedSelector = attr + (selector + '').replace(',', ',' + attr, 'g');
-	let result = all ? element.querySelectorAll(scopedSelector) : element.querySelector(scopedSelector);
-	if (!id) {
-		element.removeAttribute('id');
-	}
-	return result;
+    if (typeof selector !== 'string') {
+        console.warn('Query selector must be string!');
+        return;
+    }
+    let id = element.id,
+        guid = element.id = id || 'query_children_' + _idCount++,
+        attr = '#' + guid + ' > ',
+        scopedSelector = attr + (selector + '').replace(',', ',' + attr, 'g');
+    let result = all ? element.querySelectorAll(scopedSelector) : element.querySelector(scopedSelector);
+    if (!id) {
+        element.removeAttribute('id');
+    }
+    return result;
 }
 
 /**
@@ -67,7 +67,7 @@ function queryChildren(element, selector, all = false) {
 let byContentVal = makeDecorator(function() {
     return function (target, key, descriptor) {
         if (target.addProperty) {
-			descriptor.writable = true;
+            descriptor.writable = true;
             target.addProperty(key, (element) => {
                 return element && element.innerText;
             });
@@ -226,28 +226,28 @@ let byContent = makeDecorator(function(selector) {
         descriptor.writable = true;
         if (target.addProperty) {
             target.addProperty(key, (element) => {
-				if (element && (element instanceof HTMLElement)) {
-					let node = null;
+                if (element && (element instanceof HTMLElement)) {
+                    let node = null;
 
-					let valueFn = () => {
-						if (!node) {
-							let child = queryChildren(element, selector);
-							if (child) {
-								node = <EmbedNode item={ makeDOMNode(child, selector) }/>;
-							}
-						}
-						return node;
-					}
-					let result = valueFn();
-					if (!result) {
-						// We could not match the selector. That is possibly because 
-						// a rendering engine has not filled in the children yet.
-						// Watch for DOM mutations that add a matching element
-						attachContentObserver(target, key, element, element, valueFn);
-					}
-					return valueFn();
-				}
-			});
+                    let valueFn = () => {
+                        if (!node) {
+                            let child = queryChildren(element, selector);
+                            if (child) {
+                                node = <EmbedNode item={ makeDOMNode(child, selector) }/>;
+                            }
+                        }
+                        return node;
+                    }
+                    let result = valueFn();
+                    if (!result) {
+                        // We could not match the selector. That is possibly because 
+                        // a rendering engine has not filled in the children yet.
+                        // Watch for DOM mutations that add a matching element
+                        attachContentObserver(target, key, element, element, valueFn);
+                    }
+                    return valueFn();
+                }
+            });
         }
     }
 });
@@ -430,8 +430,8 @@ let registerEvent = makeDecorator(function(eventName) {
 export { 
     byAttrVal,
     byBooleanAttrVal,
-	byContentVal,
-	byContent,
+    byContentVal,
+    byContent,
     byChildContentVal,
     byJsonAttrVal,
     byModel,

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -13,7 +13,7 @@ import DOMNode from './DOMNode';
 import EmbedNode from './EmbedNode';
 import React from 'react';
 
-var _idCount = 0;
+let _idCount = 0;
 
 function makeDecorator(callback) {
     return function (...args) {
@@ -36,7 +36,7 @@ function makeDOMNode(target, selector) {
 function findCommentNode(element, selector) {
     for(let i = 0; i < element.childNodes.length; i++) {
         let node = element.childNodes[i];
-        if( node.nodeType === 8
+        if( node.nodeType === Node.COMMENT_NODE
             && node._reactComponentDataNode
             && node._reactComponentDataNode.selector === selector) {
             return node;

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -9,6 +9,10 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+import DOMNode from './DOMNode';
+import EmbedNode from './EmbedNode'
+
+var _idCount = 0;
 
 function makeDecorator(callback) {
     return function (...args) {
@@ -20,6 +24,41 @@ function makeDecorator(callback) {
     }
 }
 
+function makeDOMNode(target, selector) {
+    const dataNode = new DOMNode();
+    dataNode.node = target;
+    dataNode.selector = selector;
+    target._reactComponentDataNode = dataNode;
+    return dataNode;
+}
+
+function findCommentNode(element, selector) {
+	for(let i = 0; i < element.childNodes.length; i++) {
+		let node = element.childNodes[i];
+		if( node.nodeType === 8
+			&& node._reactComponentDataNode
+			&& node._reactComponentDataNode.selector === selector) {
+			return node;
+		}
+	}
+}
+
+function queryChildren(element, selector, all = false) {
+	if (typeof selector !== 'string') {
+		console.warn('Query selector must be string!');
+		return;
+	}
+	let id = element.id,
+		guid = element.id = id || 'query_children_' + _idCount++,
+		attr = '#' + guid + ' > ',
+		scopedSelector = attr + (selector + '').replace(',', ',' + attr, 'g');
+	let result = all ? element.querySelectorAll(scopedSelector) : element.querySelector(scopedSelector);
+	if (!id) {
+		element.removeAttribute('id');
+	}
+	return result;
+}
+
 /**
  * Parses the element and returns the innerText
  * 
@@ -28,12 +67,14 @@ function makeDecorator(callback) {
 let byContentVal = makeDecorator(function() {
     return function (target, key, descriptor) {
         if (target.addProperty) {
+			descriptor.writable = true;
             target.addProperty(key, (element) => {
                 return element && element.innerText;
             });
         }
     }
 });
+
 
 /**
  * Parses the element and returns the value of the provided attribute
@@ -168,6 +209,48 @@ function attachContentObserver(target, key, element, child, valueFn) {
         }   
     }
 }
+
+/**
+ * Adds to the model a property that returns a react component that, when 
+ * rendered, will produce the node matched by the given selector. The 
+ * React component will "steal" the DOM node from it's original parent.
+ * If the React component is later removed from the render tree, the DOM
+ * node that was stolen will be replaced in its original parent.
+ * 
+ * @param {String} selector - the selector for the child to turn into a React component
+ * 
+ * @returns {function} - the decorator function
+*/
+let byContent = makeDecorator(function(selector) {
+    return function (target, key, descriptor) {
+        descriptor.writable = true;
+        if (target.addProperty) {
+            target.addProperty(key, (element) => {
+				if (element && (element instanceof HTMLElement)) {
+					let node = null;
+
+					let valueFn = () => {
+						if (!node) {
+							let child = queryChildren(element, selector);
+							if (child) {
+								node = <EmbedNode item={ makeDOMNode(child, selector) }/>;
+							}
+						}
+						return node;
+					}
+					let result = valueFn();
+					if (!result) {
+						// We could not match the selector. That is possibly because 
+						// a rendering engine has not filled in the children yet.
+						// Watch for DOM mutations that add a matching element
+						attachContentObserver(target, key, element, element, valueFn);
+					}
+					return valueFn();
+				}
+			});
+        }
+    }
+});
 
 /**
  * Parses the element and returns the innerText of the child element with the provided name
@@ -347,7 +430,8 @@ let registerEvent = makeDecorator(function(eventName) {
 export { 
     byAttrVal,
     byBooleanAttrVal,
-    byContentVal,
+	byContentVal,
+	byContent,
     byChildContentVal,
     byJsonAttrVal,
     byModel,

--- a/lib/dom-model/DOMNode.js
+++ b/lib/dom-model/DOMNode.js
@@ -1,0 +1,175 @@
+/*
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* eslint no-constant-condition: "off" */
+
+const domNodeMutationOptions = { childList: true };
+
+function handleDOMNodeMutation(mutations, observer) {
+    const domNode = observer._domNode;
+    if (!domNode.stolen) {
+        return;
+    }
+    const node = domNode.node;
+    const parentNode = node.parentNode;
+    if (!parentNode) {
+        domNode.applicationDidRemoveItem();
+    }
+}
+/**
+* This is a container around a HTMLElement which allows for the element to be removed from the DOM
+* replaced with a comment and then returned back to the DOM
+*/
+export default class DOMNode {
+    placeholder;
+    node;
+    stolen;
+    /**
+    * Removes the node from the DOM and replaces with a comment
+    * @returns {HTMLElement} - the HTML DOM node
+    */
+    stealNode() {
+        if (this.stolen) {
+            return null;
+        }
+
+        const node = this.node;
+        this.returned = false;
+
+        var placeholder = this.placeholder;
+        if (!placeholder) {
+            placeholder = this.placeholder = document.createComment('placeholder for ' + node.nodeName);
+            placeholder._reactComponentDataNode = this;
+        }
+
+        node.parentNode.replaceChild(placeholder, node);
+        this.stolen = true;
+        return this.node;
+    }
+
+    /**
+    * Returns the node to the DOM. It replaceses the comment with the node
+    */
+    returnNode() {
+        if (!this.stolen) {
+            return;
+        }
+
+        this.stolen = false;
+        this.returned = true;
+        this.stopObserving();
+
+        const placeholder = this.placeholder;
+        const placeholderParent = placeholder.parentNode;
+        if (placeholderParent) {
+            placeholderParent.replaceChild(this.node, placeholder);
+        }
+    }
+
+    /**
+    * Observes the mutations of the parent node to check if the users are removing the node.
+    */
+    observe() {
+        if (this.observer) {
+            this.stopObserving();
+        }
+        const observer = this.observer = new MutationObserver(handleDOMNodeMutation);
+        observer._domNode = this;
+        observer.observe(this.node.parentNode, domNodeMutationOptions);
+    }
+
+    /**
+    * Stops the mutation observer
+    */
+    stopObserving() {
+        const observer = this.observer;
+        if (observer) {
+            observer.disconnect();
+            this.observer = null;
+        }
+    }
+
+    /**
+    * Marks that the application removed the item
+    */
+    applicationDidRemoveItem() {
+        this.stolen = false;
+        this.returned = true;
+        this.stopObserving();
+        this.remove();
+    }
+
+    /**
+    * Adds the node to the list of child elements.
+    * It will look for the correct position in the list of the element.
+    * @param {Array<Object>} - the list of the child element
+    */
+    add(list) {
+
+        this.list = list;
+        var target = this.span || this.node;
+        do {
+            target = target.previousSibling;
+            if (!target) {
+                // this is the first item, just insert it at the very top.
+                list.splice(0, 0, this);
+                return;
+            }
+            const data = target._reactComponentDataNode;
+            if (data) {
+                // If the element is stolen, then we need to use the placeholder and not
+                // the actual element. Otherwise the element might actually be added to the same
+                // list of elements and might use the wrong position.
+                if (data.stolen && data.placeholder !== target) {
+                    // Continue until we find the right element.
+                    continue;
+                }
+                const index = list.indexOf(data);
+                if (index !== -1) {
+                    list.splice(index + 1, 0, this);
+                    return;
+                }
+            }
+        } while (true);
+    }
+
+    /**
+    * Removes the node
+    */
+    remove() {
+        const list = this.list;
+        if (list) {
+            list.removeItem(this);
+            this.list = null;
+        }
+        const node = this.node;
+        if (node._reactComponentDataNode === this) {
+            node._reactComponentDataNode = null;
+        }
+        this.removePlaceholder();
+    }
+
+    /**
+    * Removes the placeholder of the node
+    */
+    removePlaceholder() {
+        const placeholder = this.placeholder;
+        if (placeholder) {
+            const placeholderParent = placeholder.parentNode;
+            if (placeholderParent) {
+                placeholderParent.removeChild(placeholder);
+            }
+        }
+    }
+}
+
+DOMNode.prototype.type = 'node';

--- a/lib/dom-model/DOMNode.js
+++ b/lib/dom-model/DOMNode.js
@@ -30,13 +30,11 @@ function handleDOMNodeMutation(mutations, observer) {
 * replaced with a comment and then returned back to the DOM
 */
 export default class DOMNode {
-    placeholder;
-    node;
-    stolen;
+
     /**
-    * Removes the node from the DOM and replaces with a comment
-    * @returns {HTMLElement} - the HTML DOM node
-    */
+     * Removes the node from the DOM and replaces with a comment
+     * @returns {HTMLElement} - the HTML DOM node
+     */
     stealNode() {
         if (this.stolen) {
             return null;
@@ -57,8 +55,8 @@ export default class DOMNode {
     }
 
     /**
-    * Returns the node to the DOM. It replaceses the comment with the node
-    */
+     * Returns the node to the DOM. It replaceses the comment with the node
+     */
     returnNode() {
         if (!this.stolen) {
             return;
@@ -76,8 +74,8 @@ export default class DOMNode {
     }
 
     /**
-    * Observes the mutations of the parent node to check if the users are removing the node.
-    */
+     * Observes the mutations of the parent node to check if the users are removing the node.
+     */
     observe() {
         if (this.observer) {
             this.stopObserving();
@@ -88,8 +86,8 @@ export default class DOMNode {
     }
 
     /**
-    * Stops the mutation observer
-    */
+     * Stops the mutation observer
+     */
     stopObserving() {
         const observer = this.observer;
         if (observer) {
@@ -99,8 +97,8 @@ export default class DOMNode {
     }
 
     /**
-    * Marks that the application removed the item
-    */
+     * Marks that the application removed the item
+     */
     applicationDidRemoveItem() {
         this.stolen = false;
         this.returned = true;
@@ -109,10 +107,10 @@ export default class DOMNode {
     }
 
     /**
-    * Adds the node to the list of child elements.
-    * It will look for the correct position in the list of the element.
-    * @param {Array<Object>} - the list of the child element
-    */
+     * Adds the node to the list of child elements.
+     * It will look for the correct position in the list of the element.
+     * @param {Array<Object>} - the list of the child element
+     */
     add(list) {
 
         this.list = list;
@@ -143,8 +141,8 @@ export default class DOMNode {
     }
 
     /**
-    * Removes the node
-    */
+     * Removes the node
+     */
     remove() {
         const list = this.list;
         if (list) {
@@ -159,8 +157,8 @@ export default class DOMNode {
     }
 
     /**
-    * Removes the placeholder of the node
-    */
+     * Removes the placeholder of the node
+     */
     removePlaceholder() {
         const placeholder = this.placeholder;
         if (placeholder) {

--- a/lib/dom-model/DOMNode.js
+++ b/lib/dom-model/DOMNode.js
@@ -169,5 +169,3 @@ export default class DOMNode {
         }
     }
 }
-
-DOMNode.prototype.type = 'node';

--- a/lib/dom-model/EmbedNode.js
+++ b/lib/dom-model/EmbedNode.js
@@ -14,28 +14,28 @@ import React, {Component} from 'react';
 
 export default class EmbedNode extends Component {
 
-	render() {
-		return <div ref={ (element) => this.element = element }/>
-	}
+    render() {
+        return <div ref={ (element) => this.element = element }/>
+    }
 
-	componentDidMount() {
-		this.parent = this.element.parentElement;
-		this.stolenNode = this.props.item.stealNode();
-		this.parent.replaceChild(this.stolenNode, this.element);
-	}
+    componentDidMount() {
+        this.parent = this.element.parentElement;
+        this.stolenNode = this.props.item.stealNode();
+        this.parent.replaceChild(this.stolenNode, this.element);
+    }
 
-	componentWillUnmount() {
-		this.parent.replaceChild(this.element, this.stolenNode);
-		this.props.item.returnNode();
-		delete this.stolenNode;
-	}
+    componentWillUnmount() {
+        this.parent.replaceChild(this.element, this.stolenNode);
+        this.props.item.returnNode();
+        delete this.stolenNode;
+    }
 
-	shouldComponentUpdate() {
-		// Prevent this node from rendering after it is mounted
-		return false;
-	}
+    shouldComponentUpdate() {
+        // Prevent this node from rendering after it is mounted
+        return false;
+    }
 
-	get hasStolenNode() {
-		return this.stolenNode != null
-	}
+    get hasStolenNode() {
+        return this.stolenNode != null
+    }
 }

--- a/lib/dom-model/EmbedNode.js
+++ b/lib/dom-model/EmbedNode.js
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import React, {Component} from 'react';
+
+export default class EmbedNode extends Component {
+
+	render() {
+		return <div ref={ (element) => this.element = element }/>
+	}
+
+	componentDidMount() {
+		this.parent = this.element.parentElement;
+		this.stolenNode = this.props.item.stealNode();
+		this.parent.replaceChild(this.stolenNode, this.element);
+	}
+
+	componentWillUnmount() {
+		this.parent.replaceChild(this.element, this.stolenNode);
+		this.props.item.returnNode();
+		delete this.stolenNode;
+	}
+
+	shouldComponentUpdate() {
+		// Prevent this node from rendering after it is mounted
+		return false;
+	}
+
+	get hasStolenNode() {
+		return this.stolenNode != null
+	}
+}

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -17,7 +17,8 @@ import { DOMModel, byJsonAttrVal, byAttrVal, byBooleanAttrVal,
     byChildRef
 } from "../../index";
 import JSONSnippet from "./snippets/json-model.html";
-import { byModel, byContentVal, byChildrenTypeArray, byChildModelVal } from "../../lib/dom-model/DOMDecorators";
+import { byModel, byContentVal, byContent, byChildrenTypeArray, byChildModelVal } from "../../lib/dom-model/DOMDecorators";
+import ReactDOM from "react-dom";
 
 describe("DOMModel", () => {
     let element, model;
@@ -330,6 +331,64 @@ describe("DOMModel", () => {
             model.fromDOM(element);
             expect(model.child).to.exist;
             expect(model.child).to.deep.equal(childModel);
+        })
+    });
+
+    describe("byContent", () => {
+        let element, model;
+
+        class ComponentItemModel extends DOMModel {
+            @byContentVal() name;
+        }
+        
+        class ComponentModel extends DOMModel {
+            @byAttrVal() size;
+            @byChildrenRefArray('component-item', ComponentItemModel) items;
+            @byContent('section') content;
+        }
+        
+        beforeEach(() => {
+            let result = makeModel(ComponentModel, `
+                <div>
+                    <component size="L">
+                        <component-item>Item 1</component-item>
+                        <component-item>Item 2</component-item>
+                        <section>
+                            <p>my content</p>
+                        </section>
+                    </component>
+                    <div id='mount-point'></div>
+                </div>
+            `);
+            element = result.element;
+            model = result.model;
+        });
+
+        it("parses the model", (done) => {
+            let mountPoint = element.querySelector('#mount-point');
+            element = element.firstElementChild;
+
+            model.fromDOM(element);
+
+            // Make sure that the rest of the model is there
+            expect(model.size).to.equal('L');
+            expect(model.items).to.exist;
+            expect(model.items).to.be.an('array');
+            expect(model.items).to.have.lengthOf(2);
+
+            expect(model.content).to.exist;
+            ReactDOM.render(model.content, mountPoint, () => {
+                let child = mountPoint.firstElementChild;
+                expect(child).to.exist;
+                expect(child.tagName).to.equal('SECTION');
+                let p = child.firstElementChild;
+                expect(p).to.exist;
+                expect(p.tagName).to.equal('P');
+                expect(p.innerText).to.equal('my content');
+
+                ReactDOM.unmountComponentAtNode(mountPoint);
+                done();
+            })
         })
     });
 });

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -365,7 +365,7 @@ describe("DOMModel", () => {
             model = result.model;
         });
 
-        it("parses the model", (done) => {
+        it("reparents captured content", (done) => {
             let mountPoint = element.querySelector('#mount-point');
             element = element.firstElementChild;
 

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -18,6 +18,7 @@ import { DOMModel, byJsonAttrVal, byAttrVal, byBooleanAttrVal,
 } from "../../index";
 import JSONSnippet from "./snippets/json-model.html";
 import { byModel, byContentVal, byContent, byChildrenTypeArray, byChildModelVal } from "../../lib/dom-model/DOMDecorators";
+import React from "react";
 import ReactDOM from "react-dom";
 
 describe("DOMModel", () => {
@@ -377,17 +378,35 @@ describe("DOMModel", () => {
             expect(model.items).to.have.lengthOf(2);
 
             expect(model.content).to.exist;
-            ReactDOM.render(model.content, mountPoint, () => {
-                let child = mountPoint.firstElementChild;
-                expect(child).to.exist;
-                expect(child.tagName).to.equal('SECTION');
-                let p = child.firstElementChild;
+            let component = <div>{ model.content }</div>
+            ReactDOM.render(component, mountPoint, () => {
+                let div = mountPoint.firstElementChild;
+                let section = div.firstElementChild;
+                expect(section).to.exist;
+                expect(section.tagName).to.equal('SECTION');
+                let p = section.firstElementChild;
                 expect(p).to.exist;
                 expect(p.tagName).to.equal('P');
                 expect(p.innerText).to.equal('my content');
 
                 ReactDOM.unmountComponentAtNode(mountPoint);
-                done();
+
+                setTimeout(() => {
+                    expect(mountPoint.firstElementChild).to.be.null;
+
+                    let component = element.querySelector('component');
+                    let section = element.querySelector('section');
+
+                    // Make sure that the content has been put back
+                    expect(section).to.exist;
+                    expect(section.tagName).to.equal('SECTION');
+                    let p = section.firstElementChild;
+                    expect(p).to.exist;
+                    expect(p.tagName).to.equal('P');
+                    expect(p.innerText).to.equal('my content');
+    
+                    done();
+                }, 1)
             })
         })
     });


### PR DESCRIPTION

## Description

This is the implementation of a @byContent decorator that would allow the capturing of arbitrary DOM content that the web component user has placed into a wrapped web component.

## Related Issue

https://github.com/adobe/react-webcomponent/issues/4

## Motivation and Context

Adding this feature would allow us to turn a React container component into a web component. So, we could write containers such as popovers and dialogs in React and wrap them as web components. The user of the web components could pass in arbitrary content to be hosted in the container.

## How Has This Been Tested?

I have developed a basic container control using this code and I have added a new test to the test suite to test it.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.