### PR TITLE
Clean up div after component is unmounted

### DIFF
--- a/lib/WebComponent.js
+++ b/lib/WebComponent.js
@@ -81,7 +81,7 @@ export class CustomElement extends HTMLElement {
         let rootEl = this;
         switch(this.constructor.renderRoot) {
             case "container":
-                rootEl = document.createElement("div");
+                rootEl = this.rootDiv = document.createElement("div");
                 this.appendChild(rootEl);
                 break;
             case "shadowRoot":
@@ -110,7 +110,11 @@ export class CustomElement extends HTMLElement {
     }
 
     disconnectedCallback() {
-        ReactDOM.unmountComponentAtNode(_rootShadows.get(this));
+		ReactDOM.unmountComponentAtNode(_rootShadows.get(this));
+		if (this.rootDiv) {
+			this.removeChild(this.rootDiv);
+			delete this.rootDiv;
+		}
         let model = _models.get(this);
         if (model) {
             model.destroy();

--- a/test/WebComponentTest.js
+++ b/test/WebComponentTest.js
@@ -111,4 +111,25 @@ describe("WebComponent", () => {
             });
         });
     });
+
+    it("should clean up when unmounted", () => {
+        customElements.whenDefined('custom-component').then(() => {
+			expect(element.querySelector('div')).to.be.null;
+
+			// CustomElement should create a container div
+			document.body.appendChild(element);
+			expect(element.querySelector('div')).to.exist;
+
+			// CustomElement clean up the container div
+			document.body.removeChild(element);
+			expect(element.querySelector('div')).to.be.null;
+
+			// Make sure that remounting it works
+			document.body.appendChild(element);
+			expect(element.querySelector('div')).to.exist;
+
+			document.body.removeChild(element);
+			expect(element.querySelector('div')).to.be.null;
+        });
+    });
 });


### PR DESCRIPTION
Fix web components that are mounted into a `container` so that they clean up the `div` that they create.

## Description

Remove the `div` that is created when the web component in unmounted

## Related Issue

https://github.com/adobe/react-webcomponent/issues/11

## Motivation and Context

I have a case where I am mounting/unmounting a component (popover) and the `div`s are piling up.

## How Has This Been Tested?

See the test that I added in the PR to detect this. It fails without my change to `WebComponent`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.