### PR TITLE
Make the `byContentVal` model decorator update

### DIFF
--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -70,12 +70,12 @@ let byContentVal = makeDecorator(function() {
         if (target.addProperty) {
             descriptor.writable = true;
             target.addProperty(key, (element) => {
-				let valueFn = () => {
-					return element && element.innerText;
-				}
-				attachContentListObserver(target, key, element, valueFn, { 
-					attributes: false, characterData: false, childList: true, subtree: false
-				});
+                let valueFn = () => {
+                    return element && element.innerText;
+                }
+                attachContentListObserver(target, key, element, valueFn, { 
+                    attributes: false, characterData: false, childList: true, subtree: false
+                });
                 return valueFn();
             });
         }

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -70,7 +70,13 @@ let byContentVal = makeDecorator(function() {
         if (target.addProperty) {
             descriptor.writable = true;
             target.addProperty(key, (element) => {
-                return element && element.innerText;
+				let valueFn = () => {
+					return element && element.innerText;
+				}
+				attachContentListObserver(target, key, element, valueFn, { 
+					attributes: false, characterData: false, childList: true, subtree: false
+				});
+                return valueFn();
             });
         }
     }
@@ -159,9 +165,8 @@ let byBooleanAttrVal = makeDecorator(function(attrName) {
  * @param   {DOMModel} target - the dom model we are attaching to
  * @param   {String} key - the name of the property we are currently on
  * @param   {HTMLElement} element -  the element that we are parsing 
- * @param   {HTMLElement} child - the element we are observing
- * @param   {Object} observeOptions - the options passed to observe method
  * @param   {function} valueFn - the function to return the value of the child
+ * @param   {Object} observeOptions - the options passed to observe method
  */
 function attachContentListObserver(target, key, element, valueFn, observeOptions ) {
     if (element && !element._isObserved) {

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -349,6 +349,41 @@ describe("DOMModel", () => {
         })
     });
 
+    describe("byContentVal", () => {
+
+        class ButtonModel extends DOMModel {
+            @byAttrVal() variant;
+            @byContentVal() label;
+		}
+		
+        beforeEach(() => {
+            let result = makeModel(ButtonModel, `
+                <my-button variant='action'>Push Me</my-button>
+            `);
+            element = result.element;
+            model = result.model;
+		});
+		
+		it("parses the model", () => {
+            expect(model.variant).to.equal('action');
+            expect(model.label).to.equal('Push Me');
+		});
+		
+		it("updates when the DOM changes", (done) => {
+            expect(model.variant).to.equal('action');
+			expect(model.label).to.equal('Push Me');
+			
+            element.addEventListener("_updateModel", (event) => {
+				let change = event.detail[0];
+				expect(change.propertyName).to.equal('label');
+				expect(change.value).to.equal('New Label');
+                done();
+			});
+			
+			element.innerHTML = 'New Label';
+		});
+	});
+
     describe("byContent", () => {
         let element, model;
 

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -354,35 +354,35 @@ describe("DOMModel", () => {
         class ButtonModel extends DOMModel {
             @byAttrVal() variant;
             @byContentVal() label;
-		}
-		
+        }
+        
         beforeEach(() => {
             let result = makeModel(ButtonModel, `
                 <my-button variant='action'>Push Me</my-button>
             `);
             element = result.element;
             model = result.model;
-		});
-		
-		it("parses the model", () => {
+        });
+        
+        it("parses the model", () => {
             expect(model.variant).to.equal('action');
             expect(model.label).to.equal('Push Me');
-		});
-		
-		it("updates when the DOM changes", (done) => {
+        });
+        
+        it("updates when the DOM changes", (done) => {
             expect(model.variant).to.equal('action');
-			expect(model.label).to.equal('Push Me');
-			
+            expect(model.label).to.equal('Push Me');
+            
             element.addEventListener("_updateModel", (event) => {
-				let change = event.detail[0];
-				expect(change.propertyName).to.equal('label');
-				expect(change.value).to.equal('New Label');
+                let change = event.detail[0];
+                expect(change.propertyName).to.equal('label');
+                expect(change.value).to.equal('New Label');
                 done();
-			});
-			
-			element.innerHTML = 'New Label';
-		});
-	});
+            });
+            
+            element.innerHTML = 'New Label';
+        });
+    });
 
     describe("byContent", () => {
         let element, model;


### PR DESCRIPTION

## Description

Makes the `byContentVal` decorator update like the other decorators, even when not used in a child node.

## Related Issue

#14 

## Motivation and Context

We have some UI that does not update because of this issue

## How Has This Been Tested?

I have tested this in my application, and I have included a test case

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.