### PR TITLE
Please consider changing behavior of `byBooleanAttrVal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ window.customElements.define("test-button", ButtonCustomElement);
 ### DOMModel
 This utility is reponsible from converting a DOM node to a model. The model is decorated with a series of specialize decorators. Each decorator will parse the dom and construct the model:
 * [byAttrVal](#byattrval)
-* [byBooleanAttrVal](#bybooleanattrval)
+* [byExistAttrVal](#byexistattrval)
 * [byJsonAttrVal](#byjsonattrval)
 * [byContentVal](#bycontentval)
 * [byContent](#bycontent)
@@ -160,17 +160,17 @@ model ~ {
 }
 ```
 
-#### byBooleanAttrVal  
+#### byExistAttrVal  
 
 Parses the element and sets the value corresponding to the presence of the attribute on the element.  
 The value of the attribute is ignored, only the presence of the attribute determines the value
 ```js
-@byBooleanAttrVal(attrName:string) - defaults to the name of the property it decorates
+@byExistAttrVal(attrName:string) - defaults to the name of the property it decorates
 ```
 ```js
 class Model extends DOMModel {
-    @byBooleanAttrVal() checked;
-    @byBooleanAttrVal("is-required") required;
+    @byExistAttrVal() checked;
+    @byExistAttrVal("is-required") required;
 }
 ```
 Usage:
@@ -351,7 +351,7 @@ All the resulting array of values is stored as the value on the decorated proper
 class OptionModel extends DOMModel {
     @byContentVal() content;
     @byAttrVal() value;
-    @byBooleanAttrVal() selected;
+    @byExistAttrVal() selected;
 }
 
 class SelectModel extends DOMModel {

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ window.customElements.define("test-button", ButtonCustomElement);
 This utility is reponsible from converting a DOM node to a model. The model is decorated with a series of specialize decorators. Each decorator will parse the dom and construct the model:
 * [byAttrVal](#byattrval)
 * [byExistAttrVal](#byexistattrval)
+* [byBooleanAttrVal](#bybooleanattrval)
 * [byJsonAttrVal](#byjsonattrval)
 * [byContentVal](#bycontentval)
 * [byContent](#bycontent)
@@ -186,6 +187,41 @@ model.fromDOM(document.getElementById("elem"));
 model ~ {
     checked: true,
     required: true
+}
+```
+
+#### byBooleanAttrVal  
+
+Parses the element and sets the value based on string value `true` or `false`, and `undefined` otherwise.
+```js
+@byBooleanAttrVal(attrName:string) - defaults to the name of the property it decorates
+```
+```js
+class Model extends DOMModel {
+    @byExistAttrVal() checked;
+}
+```
+Usage:
+```js
+<div id="elem" checked="true"/>
+model.fromDOM(document.getElementById("elem"));
+model ~ {
+    checked: true
+}
+<div id="elem" checked="false"/>
+model.fromDOM(document.getElementById("elem"));
+model ~ {
+    checked: false
+}
+<div id="elem" checked/>
+const model = new Model().fromDOM(document.getElementById("elem"));
+model ~ {
+    checked: undefined
+}
+<div id="elem" checked="anything else"/>
+model.fromDOM(document.getElementById("elem"));
+model ~ {
+    checked: undefined
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Usage:
 const model = new Model().fromDOM(document.getElementById("elem"));
 model ~ {
     checked: true,
-    required: undefined
+    required: false
 }
 <div id="elem" checked is-required/>
 model.fromDOM(document.getElementById("elem"));

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -134,7 +134,7 @@ let byJsonAttrVal = makeDecorator(function(attrName) {
     * @param {String} attrName - the name of the attribute
     * @param {Object} [config = null] - the configuration for the property
     */
-let byBooleanAttrVal = makeDecorator(function(attrName) {
+let byExistAttrVal = makeDecorator(function(attrName) {
     return function (target, key, descriptor) {
         descriptor.writable = true;
         let attributeName = attrName || key;
@@ -430,7 +430,7 @@ let registerEvent = makeDecorator(function(eventName) {
 
 export { 
     byAttrVal,
-    byBooleanAttrVal,
+    byExistAttrVal,
     byContentVal,
     byContent,
     byChildContentVal,

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -140,10 +140,6 @@ let byExistAttrVal = makeDecorator(function(attrName) {
         let attributeName = attrName || key;
         target.addAttribute(attributeName);
         target.addAttributeKey(attributeName, key);
-        let defaultValue;
-        if (descriptor.initializer) {
-            defaultValue = descriptor.initializer();
-        }
         if (target.addProperty) {
             target.addProperty(key, (element) => {
                 return element && (element.hasAttribute(attributeName));

--- a/lib/dom-model/DOMDecorators.js
+++ b/lib/dom-model/DOMDecorators.js
@@ -128,12 +128,11 @@ let byJsonAttrVal = makeDecorator(function(attrName) {
     }
 });
 
-
-    /**
-    * Creates a property that sets the value based on the existance of an attribute
-    * @param {String} attrName - the name of the attribute
-    * @param {Object} [config = null] - the configuration for the property
-    */
+/**
+* Creates a property that sets the value based on the existance of an attribute
+* @param {String} attrName - the name of the attribute
+* @param {Object} [config = null] - the configuration for the property
+*/
 let byExistAttrVal = makeDecorator(function(attrName) {
     return function (target, key, descriptor) {
         descriptor.writable = true;
@@ -143,6 +142,37 @@ let byExistAttrVal = makeDecorator(function(attrName) {
         if (target.addProperty) {
             target.addProperty(key, (element) => {
                 return element && (element.hasAttribute(attributeName));
+            });
+        };
+    }
+});
+
+/**
+* Creates a property that sets the value based on the string 'true' or 'false'
+* @param {String} attrName - the name of the attribute
+* @param {Object} [config = null] - the configuration for the property
+*/
+let byBooleanAttrVal = makeDecorator(function(attrName) {
+    return function (target, key, descriptor) {
+        descriptor.writable = true;
+        let attributeName = attrName || key;
+        target.addAttribute(attributeName);
+        target.addAttributeKey(attributeName, key);
+        let defaultValue;
+        if (descriptor.initializer) {
+            defaultValue = descriptor.initializer();
+        }
+        if (target.addProperty) {
+            target.addProperty(key, (element) => {
+                if(element && element.hasAttribute(attributeName)) {
+                    let attributeValue = element.getAttribute(attributeName);
+                    if(attributeValue === 'true') {
+                        return true;
+                    } else if(attributeValue === 'false') {
+                        return false;
+                    }
+                }
+                return defaultValue;
             });
         };
     }
@@ -427,6 +457,7 @@ let registerEvent = makeDecorator(function(eventName) {
 export { 
     byAttrVal,
     byExistAttrVal,
+    byBooleanAttrVal,
     byContentVal,
     byContent,
     byChildContentVal,

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import { expect, assert } from "chai";
 
-import { DOMModel, byJsonAttrVal, byAttrVal, byBooleanAttrVal,
+import { DOMModel, byJsonAttrVal, byAttrVal, byExistAttrVal,
     byChildContentVal, byChildrenRefArray, registerEvent,
     byChildRef
 } from "../../index";
@@ -39,7 +39,7 @@ describe("DOMModel", () => {
     class JSONModel extends DOMModel {
         @byJsonAttrVal("j-attr") jAttr;
         @byAttrVal weight;
-        @byBooleanAttrVal required;
+        @byExistAttrVal required;
         @byChildContentVal("child-value") value;
         @registerEvent change;
     }
@@ -62,7 +62,7 @@ describe("DOMModel", () => {
         });
     });
 
-    describe("byBooleanVal", () => {
+    describe("byExistAttrVal", () => {
         it("parses the value correctly", () => {
             let { model, element } = makeModel(JSONModel, JSONSnippet);
             expect(model.required).to.equal(true);
@@ -245,7 +245,7 @@ describe("DOMModel", () => {
         }
 
         class ChildType2 extends DOMModel {
-            @byBooleanAttrVal() selected;
+            @byExistAttrVal() selected;
         }
 
         class ParentModel extends DOMModel {
@@ -253,7 +253,7 @@ describe("DOMModel", () => {
                 "child-one": ChildType1,
                 "child-two": ChildType2
             }) items;
-            @byBooleanAttrVal() disabled;
+            @byExistAttrVal() disabled;
         }
 
         beforeEach(() => {

--- a/test/dom-model/DOMModelTest.js
+++ b/test/dom-model/DOMModelTest.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import { expect, assert } from "chai";
 
-import { DOMModel, byJsonAttrVal, byAttrVal, byExistAttrVal,
+import { DOMModel, byJsonAttrVal, byAttrVal, byExistAttrVal, byBooleanAttrVal,
     byChildContentVal, byChildrenRefArray, registerEvent,
     byChildRef
 } from "../../index";
@@ -40,6 +40,7 @@ describe("DOMModel", () => {
         @byJsonAttrVal("j-attr") jAttr;
         @byAttrVal weight;
         @byExistAttrVal required;
+        @byBooleanAttrVal("close-on-select") closeOnSelect;
         @byChildContentVal("child-value") value;
         @registerEvent change;
     }
@@ -69,6 +70,25 @@ describe("DOMModel", () => {
             element.removeAttribute("required");
             model.fromDOM(element);
             expect(model.required).to.equal(false);
+        });
+    });
+
+    describe("byBooleanAttrVal", () => {
+        it("parses the value correctly", () => {
+            let { model, element } = makeModel(JSONModel, JSONSnippet);
+            expect(model.closeOnSelect).to.equal(undefined);
+            element.removeAttribute("close-on-select");
+            model.fromDOM(element);
+            expect(model.closeOnSelect).to.equal(undefined);
+            element.setAttribute("close-on-select", "true");
+            model.fromDOM(element);
+            expect(model.closeOnSelect).to.equal(true);
+            element.setAttribute("close-on-select", "false");
+            model.fromDOM(element);
+            expect(model.closeOnSelect).to.equal(false);
+            element.setAttribute("close-on-select", "random");
+            model.fromDOM(element);
+            expect(model.closeOnSelect).to.equal(undefined);
         });
     });
 

--- a/test/dom-model/snippets/json-model.html
+++ b/test/dom-model/snippets/json-model.html
@@ -1,3 +1,3 @@
-<custom-component j-attr='[{"example":1},{"test":2}]' weight="3" required>
+<custom-component j-attr='[{"example":1},{"test":2}]' weight="3" required close-on-select>
     <child-value>Test content</child-value>
 </custom-component>


### PR DESCRIPTION
## Description

The behavior of the current `byBooleanAttrVal` returns true or false based on the existence of an attribute. This change renames that behavior to `byExistAttrVal`.

The new `byBooleanAttrVal` will return true or false based on the literal string value (e.g. `"true"` or `"false"`) and will return `undefined` for other cases, including lack of existence of the attribute.

## Related Issue

https://github.com/adobe/react-webcomponent/issues/13

## Motivation and Context

If you create a React component with an optional boolean prop that defaults to `true`, the current behavior of `byBooleanAttrVal` looks at an attribute being missing and passes an explicit `false` to the React component, short-circuiting the default handling logic.

It would be desirable in this case to pass `undefined` to the React component, so the default handling logic works.

## How Has This Been Tested?

`npm run test`

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x]  I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.