### PR TITLE
Fix possible exception with ReactDOM.unmountComponentAtNode

### DIFF
--- a/lib/WebComponent.js
+++ b/lib/WebComponent.js
@@ -110,7 +110,11 @@ export class CustomElement extends HTMLElement {
     }
 
     disconnectedCallback() {
-		ReactDOM.unmountComponentAtNode(_rootShadows.get(this));
+        const rootEl = _rootShadows.get(this);
+        if(rootEl) {
+            ReactDOM.unmountComponentAtNode(_rootShadows.get(this));
+        }
+
 		if (this.rootDiv) {
 			this.removeChild(this.rootDiv);
 			delete this.rootDiv;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a potential exception with the `ReactDOM.unmountComponentAtNode` method call when the result of `_rootShadows.get(this)` is undefined.

I could consistently reproduce the issue in the context of the AEM editor, but couldn't find a minimal example to demonstrate the issue.

```
react-dom.development.js:27628 Uncaught Error: unmountComponentAtNode(...): Target container is not a DOM element.
    at Object.unmountComponentAtNode (react-dom.development.js:27628)
```

## How Has This Been Tested?

Manual testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.